### PR TITLE
fix: drop Python 3.10 from CI matrix, add 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,48 +2,48 @@ name: Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
-    
+        python-version: ["3.11", "3.12", "3.13"]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-      
+          cache: "pip"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      
+
       - name: Lint with flake8
         run: |
           flake8 src/ tests/ --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 src/ tests/ --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
-      
+
       - name: Format check with black
         run: black --check src/ tests/ || true
-      
+
       - name: Type check with mypy
         run: mypy src/ --ignore-missing-imports || true
-      
+
       - name: Run tests with pytest
         run: |
           pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
-      
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -53,24 +53,24 @@ jobs:
 
   lint-and-format:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
-          cache: 'pip'
-      
+          python-version: "3.11"
+          cache: "pip"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install black flake8 isort
-      
+
       - name: Run isort
         run: isort src/ tests/ --check-only || true
-      
+
       - name: Run black
         run: black src/ tests/ --check || true


### PR DESCRIPTION
## Summary
- `pandas>=3.0.0` requires Python >=3.11, so the Python 3.10 CI matrix entry always fails at `pip install`
- Replaced 3.10 with 3.13 in the test matrix: now tests on 3.11, 3.12, 3.13

## Test plan
- [ ] Verify CI passes on all three Python versions (3.11, 3.12, 3.13)

Fixes: https://github.com/jgamblin/monthlyCVEStats/actions/runs/23722586059

🤖 Generated with [Claude Code](https://claude.com/claude-code)